### PR TITLE
Add confirmation token to users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,27 @@
 class UsersController < ApplicationController
   def create
-    @user = User.new(user_params)
+    user_creation = UserCreation.new(user_params)
+    user_creation.perform
 
-    if @user.save
-      flash[:notice] = "Thank you for signing up!"
+    if user_creation.successful?
+      assign_success_variables(user_creation.user)
       render "confirmed"
     else
-      assign_session_variables(@user)
+      assign_failure_variables(user_params)
       redirect_to root_path
     end
   end
 
   private
 
-  def assign_session_variables(user)
+  def assign_failure_variables(user_params)
     flash[:error] = "Uh-oh, something went wrong..."
-    session[:user] = user.attributes
+    session[:user] = user_params
+  end
+
+  def assign_success_variables(user)
+    flash[:notice] = "Thank you for signing up!"
+    @user = user
   end
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_secure_token :confirmation_token
+
   validates :email,
     presence: true,
     uniqueness: { case_sensitive: false },
@@ -8,6 +10,9 @@ class User < ApplicationRecord
   validates :name,
     presence: true,
     length: { maximum: 80 }
+
+  validates :confirmation_token,
+    uniqueness: { case_sensitive: false }
 
   # Validations are only run when `User#valid?` is invoked
   # To load a user with validations, call `valid?` on `self`

--- a/app/services/user_creation.rb
+++ b/app/services/user_creation.rb
@@ -1,0 +1,37 @@
+class UserCreation
+  def initialize(params)
+    @params = params
+    @success = false
+  end
+
+  def perform
+    User.transaction do
+      create_user!
+      notify_user!
+
+      @success = true
+    end
+  rescue ActiveRecord::ActiveRecordError => e
+    Rails.logger.error(e.message)
+  end
+
+  def successful?
+    success
+  end
+
+  def user
+    @_user
+  end
+
+  private
+
+  attr_reader :params, :success
+
+  def create_user!
+    @_user ||= User.create!(params)
+  end
+
+  def notify_user!
+    # TODO: send email here
+  end
+end

--- a/db/migrate/20171115154908_add_confirmation_token_to_users.rb
+++ b/db/migrate/20171115154908_add_confirmation_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddConfirmationTokenToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115094919) do
+ActiveRecord::Schema.define(version: 20171115154908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20171115094919) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "confirmation_token"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe User, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_most(80) }
+
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email).case_insensitive }
     it { should validate_length_of(:email).is_at_most(80) }
+
+    it { should validate_uniqueness_of(:confirmation_token).case_insensitive }
 
     it "can have an empty confirmation timestamp" do
       user = build(:user, confirmed_at: nil)

--- a/spec/services/user_creation_spec.rb
+++ b/spec/services/user_creation_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe UserCreation, type: :model do
+  describe "#perform" do
+    context "with valid params" do
+      it "is successful" do
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(user_creation).to be_successful
+      end
+
+      it "creates a new user" do
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        expect do
+          user_creation.perform
+        end.to change { User.count }.by(1)
+      end
+
+      it "assigns a confirmation token to the created user" do
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        user = User.find_by(user_params)
+        expect(user.confirmation_token).to be
+      end
+    end
+
+    context "with invalid params" do
+      it "is not successful" do
+        user_params = attributes_for(:user, email: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(user_creation).not_to be_successful
+      end
+
+      it "does not create a new user" do
+        user_params = attributes_for(:user, email: nil)
+        user_creation = UserCreation.new(user_params)
+
+        expect do
+          user_creation.perform
+        end.not_to change { User.count }
+      end
+    end
+  end
+
+  describe "#successful?" do
+    context "with valid params" do
+      it "is true" do
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(user_creation.successful?).to be
+      end
+    end
+
+    context "with invalid params" do
+      it "is false" do
+        user_params = attributes_for(:user, email: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(user_creation.successful?).not_to be
+      end
+    end
+  end
+
+  describe "#user" do
+    context "with valid params" do
+      it "returns the newly created user" do
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        user = User.find_by(user_params)
+        expect(user_creation.user).to eq(user)
+      end
+    end
+
+    context "with invalid params" do
+      it "returns nil" do
+        user_params = attributes_for(:user, email: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(user_creation.user).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why:

* This is required in order to have users confirm their sign up.
* To avoid very large pull requests, this change is going in immediately.

This change addresses the need by:

* Adding the required field to the users.
* Updating the validations to match.
* Extracting the user creation to a service due to the complexity it now has.