### PR TITLE
Configure mailer

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,3 @@
+export MAILER_FROM_EMAIL="noreply@includebraga.org"
+export MAILER_FROM_NAME="Secret Santa Development"
+export MAILER_HOST="localhost:5000"

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ end
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "letter_opener"
+  gem "letter_opener_web"
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "spring", require: false
   gem "spring-watcher-listen", "~> 2.0.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
     awesome_print (1.8.0)
@@ -78,6 +80,14 @@ GEM
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.1)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -106,6 +116,7 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
+    public_suffix (3.0.1)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
@@ -243,6 +254,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  letter_opener
+  letter_opener_web
   listen (>= 3.0.5, < 3.2)
   pg
   pry-rails

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAILER_FROM_NAME") + "<#{ENV.fetch('MAILER_FROM_EMAIL')}>"
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,7 @@
+class UserMailer < ApplicationMailer
+  def new_user(user)
+    @confirmation_url = users_confirmation_url(user.confirmation_token)
+
+    mail to: user.email, subject: "[Secret Santa] Confirm your email"
+  end
+end

--- a/app/services/user_creation.rb
+++ b/app/services/user_creation.rb
@@ -32,6 +32,6 @@ class UserCreation
   end
 
   def notify_user!
-    # TODO: send email here
+    UserMailer.new_user(user).deliver_now
   end
 end

--- a/app/views/user_mailer/new_user.html.slim
+++ b/app/views/user_mailer/new_user.html.slim
@@ -1,0 +1,7 @@
+h1 Thank you for signing up!
+
+p Your contribution means the world to us ❤️
+
+p We need you to confirm your email by clicking #{link_to "this link", @confirmation_url}.
+
+p You can also copy and paste this into your address bar: #{@confirmation_url}

--- a/app/views/user_mailer/new_user.txt.erb
+++ b/app/views/user_mailer/new_user.txt.erb
@@ -1,0 +1,7 @@
+Thank you for signing up!
+
+Your contribution means the world to us ❤️
+
+We need you to confirm your email by clicking <%= link_to "this link", @confirmation_url %>.
+
+You can also copy and paste this into your address bar: <%= @confirmation_url %>

--- a/app/views/users/create.slim
+++ b/app/views/users/create.slim
@@ -5,5 +5,3 @@ p Thank you for signing up!
 p Your contribution means the world to us ❤️
 
 p Please confirm your email by clicking the link we just sent to #{@user.email}
-
-p DEBUG: #{link_to confirmation_path(@user.confirmation_token), confirmation_path(@user.confirmation_token)}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,10 +26,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :letter_opener_web
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,19 @@
+ActionMailer::Base.default_url_options = {
+  host: ENV.fetch("MAILER_HOST", "localhost:5000"),
+  protocol: "http",
+}
+
+if %w(production staging).include?(Rails.env)
+  ActionMailer::Base.raise_delivery_errors = true
+  ActionMailer::Base.delivery_method = :smtp
+
+  ActionMailer::Base.smtp_settings = {
+    user_name: ENV.fetch("MAILER_USERNAME"),
+    password: ENV.fetch("MAILER_PASSWORD"),
+    domain: ENV.fetch("MAILER_HOST"),
+    address: ENV.fetch("MAILER_ADDRESS"),
+    port: ENV.fetch("MAILER_PORT").to_i,
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,8 @@ Rails.application.routes.draw do
   namespace :users do
     get "/confirm/:token", to: "confirmations#create", as: :confirmation
   end
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/spec/services/user_creation_spec.rb
+++ b/spec/services/user_creation_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe UserCreation, type: :model do
         user = User.find_by(user_params)
         expect(user.confirmation_token).to be
       end
+
+      it "emails the newly created user" do
+        email = double("email", deliver_now: true)
+        allow(UserMailer).to receive(:new_user).and_return(email)
+        user_params = attributes_for(:user, confirmed_at: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(email).to have_received(:deliver_now)
+      end
     end
 
     context "with invalid params" do
@@ -49,6 +60,17 @@ RSpec.describe UserCreation, type: :model do
         expect do
           user_creation.perform
         end.not_to change { User.count }
+      end
+
+      it "does not send any emails" do
+        email = double("email", deliver_now: true)
+        allow(UserMailer).to receive(:new_user).and_return(email)
+        user_params = attributes_for(:user, email: nil)
+        user_creation = UserCreation.new(user_params)
+
+        user_creation.perform
+
+        expect(email).not_to have_received(:deliver_now)
       end
     end
   end


### PR DESCRIPTION
Why:

* We need to send emails to confirm the users

This change addresses the need by:

* Configuring the mailer to account for services like SendGrid.
* Adding LetterOpener to see sent mails in the browser.
* Updating the UserCreation service to send an email to the newly
created user.