### PR TITLE
Upgrade Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,15 +9,28 @@ AllCops:
     - "bin/**/*"
     - "vendor/**/*"
     - "node_modules/**/*"
-    - "spec/factories.rb"
     - "Gemfile"
   TargetRubyVersion: 2.4
 
 Metrics/LineLength:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Naming/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -25,16 +38,8 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/DotPosition:
-  EnforcedStyle: trailing
-
 Style/IfUnlessModifier:
   Enabled: false
-
-Style/PredicateName:
-  NamePrefixBlacklist:
-    - is_
-    - have_
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -45,12 +50,6 @@ Style/NumericLiterals:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
-Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
@@ -59,3 +58,15 @@ Style/TrailingCommaInLiteral:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+    - lib/tasks/**/*.rake
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
   gem "faker"
   gem "pry-remote"
   gem "rspec-rails", "~> 3.5.1"
-  gem "rubocop", "0.43.0", require: false
+  gem "rubocop", require: false
   gem "scss_lint", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    parallel (1.12.0)
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
@@ -150,7 +151,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.2.1)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -171,10 +172,11 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.43.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
@@ -264,7 +266,7 @@ DEPENDENCIES
   rails (~> 5.1.3)
   rails-controller-testing
   rspec-rails (~> 3.5.1)
-  rubocop (= 0.43.0)
+  rubocop
   sass-rails (~> 5.0)
   scss_lint
   shoulda-matchers

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i(lint:all spec)
+task default: %i[lint:all spec]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
-if %w(development test).include? Rails.env
+if %w[development test].include? Rails.env
   namespace :lint do
     desc "Run all linters"
-    task all: %i(lint:ruby lint:scss)
+    task all: %i[lint:ruby lint:scss]
   end
 end

--- a/lib/tasks/lint/ruby.rake
+++ b/lib/tasks/lint/ruby.rake
@@ -1,4 +1,4 @@
-if %w(development test).include? Rails.env
+if %w[development test].include? Rails.env
   namespace :lint do
     require "rubocop/rake_task"
     RuboCop::RakeTask.new(:ruby)

--- a/lib/tasks/lint/scss.rake
+++ b/lib/tasks/lint/scss.rake
@@ -1,4 +1,4 @@
-if %w(development test).include? Rails.env
+if %w[development test].include? Rails.env
   require "scss_lint/rake_task"
 
   namespace :lint do


### PR DESCRIPTION
Why:

* There is a [known security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418) in the version of rubocop we were using.

This change addresses the need by:

* Upgrading Rubocop to a version where the vulnerability is fixed.