### PR TITLE
Fix confirmation token generation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  has_secure_token :confirmation_token
-
   validates :email,
     presence: true,
     uniqueness: { case_sensitive: false },
@@ -12,7 +10,7 @@ class User < ApplicationRecord
     length: { maximum: 80 }
 
   validates :confirmation_token,
-    uniqueness: { case_sensitive: false }
+    uniqueness: { case_sensitive: true }
 
   # Validations are only run when `User#valid?` is invoked
   # To load a user with validations, call `valid?` on `self`

--- a/app/services/user_creation.rb
+++ b/app/services/user_creation.rb
@@ -28,10 +28,29 @@ class UserCreation
   attr_reader :params, :success
 
   def create_user!
-    @_user ||= User.create!(params)
+    @_user ||= User.create!(user_params)
   end
 
   def notify_user!
     UserMailer.new_user(user).deliver_now
+  end
+
+  def user_params
+    params.merge(confirmation_token: generate_random_token)
+  end
+
+  def generate_random_token
+    token_candidate = new_random_token
+
+    loop do
+      break unless User.find_by(confirmation_token: token_candidate)
+      token_candidate = new_random_token
+    end
+
+    token_candidate
+  end
+
+  def new_random_token
+    SecureRandom.urlsafe_base64(32)
   end
 end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Users::ConfirmationsController, type: :controller do
   describe "GET #create" do
     context "with a valid token" do
       it "confirms the user" do
-        user = create(:user, confirmed_at: nil)
+        user = create(:user_with_confirmation_token)
 
         get :create, params: { token: user.confirmation_token }
 
@@ -12,7 +12,7 @@ RSpec.describe Users::ConfirmationsController, type: :controller do
       end
 
       it "renders the correct template" do
-        user = create(:user, confirmed_at: nil)
+        user = create(:user_with_confirmation_token)
 
         get :create, params: { token: user.confirmation_token }
 
@@ -20,7 +20,7 @@ RSpec.describe Users::ConfirmationsController, type: :controller do
       end
 
       it "404s if the token has already been used" do
-        user = create(:user, confirmed_at: nil)
+        user = create(:user_with_confirmation_token)
         get :create, params: { token: user.confirmation_token }
 
         get :create, params: { token: user.confirmation_token }
@@ -31,7 +31,7 @@ RSpec.describe Users::ConfirmationsController, type: :controller do
 
     context "with an invalid token" do
       it "404s" do
-        create(:user, confirmed_at: nil)
+        create(:user_with_confirmation_token)
 
         get :create, params: { token: "fake token" }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     name { Faker::Name.name }
     confirmed_at { Time.now }
   end
+
+  factory :user_with_confirmation_token, class: User do
+    email { Faker::Internet.email }
+    name { Faker::Name.name }
+    confirmation_token { |n| n }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe User, type: :model do
     it { should validate_uniqueness_of(:email).case_insensitive }
     it { should validate_length_of(:email).is_at_most(80) }
 
-    it { should validate_uniqueness_of(:confirmation_token).case_insensitive }
+    it { should validate_uniqueness_of(:confirmation_token) }
 
     it "can have an empty confirmation timestamp" do
       user = build(:user, confirmed_at: nil)

--- a/spec/services/user_confirmation_spec.rb
+++ b/spec/services/user_confirmation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UserConfirmation, type: :model do
 
     context "with an invalid token" do
       it "does not alter any existing users" do
-        user = create(:user, confirmed_at: nil)
+        user = create(:user_with_confirmation_token)
         user_confirmation = UserConfirmation.new("fake token")
 
         user_confirmation.perform

--- a/spec/services/user_creation_spec.rb
+++ b/spec/services/user_creation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UserCreation, type: :model do
   describe "#perform" do
     context "with valid params" do
       it "is successful" do
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -13,7 +13,7 @@ RSpec.describe UserCreation, type: :model do
       end
 
       it "creates a new user" do
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         expect do
@@ -22,19 +22,19 @@ RSpec.describe UserCreation, type: :model do
       end
 
       it "assigns a confirmation token to the created user" do
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
 
-        user = User.find_by(user_params)
+        user = User.find_by(email: user_params[:email])
         expect(user.confirmation_token).to be
       end
 
       it "emails the newly created user" do
         email = double("email", deliver_now: true)
         allow(UserMailer).to receive(:new_user).and_return(email)
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -45,7 +45,7 @@ RSpec.describe UserCreation, type: :model do
 
     context "with invalid params" do
       it "is not successful" do
-        user_params = attributes_for(:user, email: nil)
+        user_params = attributes_for(:user_with_confirmation_token, email: nil)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -54,7 +54,7 @@ RSpec.describe UserCreation, type: :model do
       end
 
       it "does not create a new user" do
-        user_params = attributes_for(:user, email: nil)
+        user_params = attributes_for(:user_with_confirmation_token, email: nil)
         user_creation = UserCreation.new(user_params)
 
         expect do
@@ -65,7 +65,7 @@ RSpec.describe UserCreation, type: :model do
       it "does not send any emails" do
         email = double("email", deliver_now: true)
         allow(UserMailer).to receive(:new_user).and_return(email)
-        user_params = attributes_for(:user, email: nil)
+        user_params = attributes_for(:user_with_confirmation_token, email: nil)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -78,7 +78,7 @@ RSpec.describe UserCreation, type: :model do
   describe "#successful?" do
     context "with valid params" do
       it "is true" do
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -89,7 +89,7 @@ RSpec.describe UserCreation, type: :model do
 
     context "with invalid params" do
       it "is false" do
-        user_params = attributes_for(:user, email: nil)
+        user_params = attributes_for(:user_with_confirmation_token, email: nil)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
@@ -102,19 +102,19 @@ RSpec.describe UserCreation, type: :model do
   describe "#user" do
     context "with valid params" do
       it "returns the newly created user" do
-        user_params = attributes_for(:user, confirmed_at: nil)
+        user_params = attributes_for(:user_with_confirmation_token)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform
 
-        user = User.find_by(user_params)
+        user = User.find_by(email: user_params[:email])
         expect(user_creation.user).to eq(user)
       end
     end
 
     context "with invalid params" do
       it "returns nil" do
-        user_params = attributes_for(:user, email: nil)
+        user_params = attributes_for(:user_with_confirmation_token, email: nil)
         user_creation = UserCreation.new(user_params)
 
         user_creation.perform


### PR DESCRIPTION
Why:

* Rails' `has_secure_token` indeed gives us a random unique token but
only if the app is not restarted.

This change addresses the need by:

* Generating a unique URL Safe token manually.