### PR TITLE
Move mailer environment variables to secrets.yml

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("MAILER_FROM_NAME") + "<#{ENV.fetch('MAILER_FROM_EMAIL')}>"
+  FROM_NAME = Rails.application.secrets.mailer_from_name.freeze
+  FROM_EMAIL = Rails.application.secrets.mailer_from_email.freeze
+
+  default from: "#{FROM_NAME} <#{FROM_EMAIL}>"
   layout "mailer"
 end

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,5 +1,5 @@
 ActionMailer::Base.default_url_options = {
-  host: ENV.fetch("MAILER_HOST", "localhost:5000"),
+  host: Rails.application.secrets.mailer_host,
   protocol: "http",
 }
 
@@ -8,11 +8,11 @@ if %w(production staging).include?(Rails.env)
   ActionMailer::Base.delivery_method = :smtp
 
   ActionMailer::Base.smtp_settings = {
-    user_name: ENV.fetch("MAILER_USERNAME"),
-    password: ENV.fetch("MAILER_PASSWORD"),
-    domain: ENV.fetch("MAILER_DOMAIN"),
-    address: ENV.fetch("MAILER_ADDRESS"),
-    port: ENV.fetch("MAILER_PORT").to_i,
+    user_name: Rails.application.secrets.mailer_username,
+    password: Rails.application.secrets.mailer_password,
+    domain: Rails.application.secrets.mailer_domain,
+    address: Rails.application.secrets.mailer_address,
+    port: Rails.application.secrets.mailer_port,
     :authentication => :plain,
     :enable_starttls_auto => true
   }

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,9 +19,17 @@
 
 development:
   secret_key_base: e1b9fa53dacaaee8275e2e807e0e8c36e93bcb58c284a9377c9fc9e62d5c24d96ecc15fd7abcba94b2e4b262649afa46803bb7e425e0d21c7d174626ed76047e
+  mailer_from_email: development@includebraga.org
+  mailer_from_name: Development Santa
+  mailer_host: localhost:5000
+  mailer_domain: localhost:5000
 
 test:
   secret_key_base: e5bd45cd9c9c3c522ba707fa0ec1ba3d70cc4d9a20972838694f085cb1b495f26c3c7a3e182da1c2ce9357d9d957caea2d8d8ba1eb61eec09deabcce5057805e
+  mailer_from_email: test@includebraga.org
+  mailer_from_name: Test Santa
+  mailer_host: localhost:5000
+  mailer_domain: localhost:5000
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -30,3 +38,11 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  mailer_from_email: <%= ENV["MAILER_FROM_EMAIL"] %>
+  mailer_from_name: <%= ENV["MAILER_FROM_NAME"] %>
+  mailer_username: <%= ENV["MAILER_USERNAME"] %>
+  mailer_password: <%= ENV["MAILER_PASSWORD"] %>
+  mailer_host: <%= ENV["MAILER_HOST"] %>
+  mailer_domain: <%= ENV["MAILER_DOMAIN"] %>
+  mailer_address: <%= ENV["MAILER_ADDRESS"] %>
+  mailer_port: <%= ENV["MAILER_PORT"].to_i %>


### PR DESCRIPTION
Why:

* Since we are testing emails, specs cannot be run without having
environment variables.
* Programs like `direnv` can be used, gems like `dotenv` or even by
providing defaults to the `ENV#fetch` calls.

This change addresses the need by:

* Setting defaults in the `config/secrets.yml`. This way no other
dependencies are required.
* This choice was taken because environment variables are only being
used in this particular use case. Should those be required elsewhere,
this option is not sustainable and should be replaced by something like
`dotenv-rails`.