### PR TITLE
Set up Timber logs

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,6 +1,7 @@
 # These commented out variables are required to simulate a production environment
 # If you are simply running in development mode, leave them be
 # export BASIC_AUTH=""
+# export TIMBER_API_KEY=""
 # export MAILER_USERNAME=""
 # export MAILER_PASSWORD=""
 # export MAILER_ADDRESS=""

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rails", "~> 5.1.3"
 gem "sass-rails", "~> 5.0"
 gem "sentry-raven"
 gem "slim-rails"
+gem "timber", "~> 2.2"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    msgpack (1.1.0)
     multipart-post (2.0.0)
     nio4r (2.1.0)
     nokogiri (1.8.1)
@@ -231,6 +232,8 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timber (2.5.1)
+      msgpack (~> 1.0)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
@@ -280,6 +283,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  timber (~> 2.2)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,10 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Install the Timber.io logger, send logs over HTTP.
+  log_device = Timber::LogDevices::HTTP.new(ENV['TIMBER_API_KEY'])
+  logger = Timber::Logger.new(log_device)
+  logger.level = config.log_level
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
 end

--- a/config/initializers/timber.rb
+++ b/config/initializers/timber.rb
@@ -1,0 +1,3 @@
+config = Timber::Config.instance
+config.integrations.action_view.silence = Rails.env.production?
+Timber.config.logrageify!()


### PR DESCRIPTION
This PR integrates our production logs with the [timber.io](timber.io) service. It also simplifies the logs for better readability.

Only thing missing is getting an API key and add it to Heroku via an environment variable `TIMBER_API_KEY`.

To setup Heroku integration we should also setup this log drain:
```
heroku drains:add https://{{timber-api-key}}@logs.timber.io/frames -a APP-NAME
```