### PR TITLE
Fix 404 when users attempt to confirm

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,8 @@ class User < ApplicationRecord
     length: { maximum: 80 }
 
   validates :confirmation_token,
-    uniqueness: { case_sensitive: true }
+    uniqueness: { case_sensitive: true },
+    allow_nil: true
 
   # Validations are only run when `User#valid?` is invoked
   # To load a user with validations, call `valid?` on `self`

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe User, type: :model do
 
       expect(user).to be_valid
     end
+
+    it "ignores nils when testing the confirmation token's uniqueness" do
+      create(:user, confirmation_token: nil)
+      user = build(:user, confirmation_token: nil)
+
+      expect(user).to be_valid
+    end
   end
 
   describe "#with_validations" do


### PR DESCRIPTION
Why:

* The uniqueness validation fails if there are multiple users with a `nil`
confirmation token.
* This means the UserConfirmation service will fail and the controller
will redirect to 404.

This change addresses the need by:

* Having the uniqueness validation ignore nils.
* Adding a relevant spec.