### PR TITLE
Fix migrations

### DIFF
--- a/app/models/instituition.rb
+++ b/app/models/instituition.rb
@@ -3,7 +3,6 @@ class Instituition < ApplicationRecord
 
   validates :name,
     presence: true,
-    uniqueness: { case_sensitive: false },
     length: { maximum: 80 }
 
   validates :short_name,

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,5 +1,6 @@
 class Match < ApplicationRecord
   belongs_to :user
   belongs_to :receiver
-  validates_uniqueness_of :user_id, scope: :receiver_id
+
+  validates :user_id, uniqueness: { scope: :receiver_id }
 end

--- a/db/migrate/20171206113215_create_instituitions.rb
+++ b/db/migrate/20171206113215_create_instituitions.rb
@@ -6,5 +6,7 @@ class CreateInstituitions < ActiveRecord::Migration[5.1]
 
       t.timestamps
     end
+
+    add_index :instituitions, :short_name, unique: true
   end
 end

--- a/db/migrate/20171206145156_create_matches.rb
+++ b/db/migrate/20171206145156_create_matches.rb
@@ -1,11 +1,12 @@
 class CreateMatches < ActiveRecord::Migration[5.1]
   def change
     create_table :matches do |t|
-      t.integer :user_id
-      t.integer :receiver_id
+      t.references :user, foreign_key: true
+      t.references :receiver, foreign_key: true
 
       t.timestamps
     end
-    add_index :matches, [:user_id, :receiver_id]
+
+    add_index :matches, [:user_id, :receiver_id], unique: true
   end
 end


### PR DESCRIPTION
This should never be done in the same migration. We should've created a new migration but it wasn't deployed yet, so I'm taking the liberty of doing it like this.