### PR TITLE
Add email sent field to matches

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -6,6 +6,6 @@ class Match < ApplicationRecord
     presence: true,
     uniqueness: { scope: :receiver_id }
 
-  validates :receiver_id,
-    presence: true
+  validates :receiver_id, presence: true
+  validates :email_sent, inclusion: { in: [true, false] }
 end

--- a/db/migrate/20171209233512_add_email_sent_to_matches.rb
+++ b/db/migrate/20171209233512_add_email_sent_to_matches.rb
@@ -1,0 +1,5 @@
+class AddEmailSentToMatches < ActiveRecord::Migration[5.1]
+  def change
+    add_column :matches, :email_sent, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171209232537) do
+ActiveRecord::Schema.define(version: 20171209233512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20171209232537) do
     t.bigint "receiver_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "email_sent", default: false
     t.index ["receiver_id"], name: "index_matches_on_receiver_id"
     t.index ["user_id", "receiver_id"], name: "index_matches_on_user_id_and_receiver_id", unique: true
     t.index ["user_id"], name: "index_matches_on_user_id"

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :match do
     user
     receiver
+
+    email_sent true
   end
 end


### PR DESCRIPTION
Why:

* When the user redeems the match for the first time we need to send him
an email containing the match as backup.
* We'll avoid sending this email multiple times by making use of a flag.

This change addresses the need by:

* Adding the `email_sent` field to matches.