### PR TITLE
Update Markdown styles

### DIFF
--- a/app/assets/stylesheets/components/base.scss
+++ b/app/assets/stylesheets/components/base.scss
@@ -8,6 +8,7 @@
 @import 'heading';
 @import 'how_it_works';
 @import 'logo';
+@import 'markdown_letter';
 @import 'questions';
 @import 'section';
 @import 'sign_up';

--- a/app/assets/stylesheets/components/markdown_letter.scss
+++ b/app/assets/stylesheets/components/markdown_letter.scss
@@ -1,0 +1,11 @@
+.MarkdownLetter {
+  i,
+  em {
+      color: $color-dark-blue-grey;
+  }
+
+  b,
+  strong {
+      color: $color-red;
+  }
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -6,6 +6,7 @@ $font-weight-regular: 400;
 $font-weight-bold: 700;
 
 $color-black: #000000;
+$color-dark-blue-grey: #2d3e50;
 $color-deep-blue: #161f28;
 $color-green: #33cc77;
 $color-red: #f95252;

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -17,11 +17,13 @@
     <title>*|MC:SUBJECT|*</title>
 
     <style type="text/css">
-        i {
-            color: #e53042;
+        i,
+        em {
+            color: #f95252;
         }
 
-        b {
+        b,
+        strong {
             color: #2d3e50;
         }
 


### PR DESCRIPTION
Why:

* The email template has different styles for bold and italic-like
texts.
* Those texts should only be present in the rendered markdown.

This change addresses the need by:

* Updating the mailer layout to use the Secret Santa red.
* Overriding tag styles under the MarkdownLetter component.