### PR TITLE
Add search by scope capabilities to administrate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "slim-rails"
 gem "timber", "~> 2.2"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
-gem "administrate"
+gem "administrate", github: "substancelab/administrate", branch: "276-collection_filters"
 gem 'webpacker'
 gem 'react-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,20 @@
+GIT
+  remote: https://github.com/substancelab/administrate.git
+  revision: 25d851c45b5162cb129199d1a861b8c47c34c679
+  branch: 276-collection_filters
+  specs:
+    administrate (0.11.0)
+      actionpack (>= 4.2, < 6.0)
+      actionview (>= 4.2, < 6.0)
+      activerecord (>= 4.2, < 6.0)
+      autoprefixer-rails (>= 6.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sass-rails (~> 5.0)
+      selectize-rails (~> 0.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -44,20 +61,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    administrate (0.11.0)
-      actionpack (>= 4.2, < 6.0)
-      actionview (>= 4.2, < 6.0)
-      activerecord (>= 4.2, < 6.0)
-      autoprefixer-rails (>= 6.0)
-      datetime_picker_rails (~> 0.0.7)
-      jquery-rails (>= 4.0)
-      kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
-      sass-rails (~> 5.0)
-      selectize-rails (~> 0.6)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.1.4)
+    autoprefixer-rails (9.3.0)
       execjs
     awesome_print (1.8.0)
     babel-source (5.8.35)
@@ -319,7 +325,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  administrate
+  administrate!
   awesome_print
   better_errors
   binding_of_caller

--- a/app/dashboards/receiver_dashboard.rb
+++ b/app/dashboards/receiver_dashboard.rb
@@ -1,6 +1,10 @@
 require "administrate/base_dashboard"
 
 class ReceiverDashboard < Administrate::BaseDashboard
+  COLLECTION_FILTERS = {
+    golden: ->(resources) { resources.golden }
+  }
+
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #

--- a/app/dashboards/receiver_dashboard.rb
+++ b/app/dashboards/receiver_dashboard.rb
@@ -3,7 +3,7 @@ require "administrate/base_dashboard"
 class ReceiverDashboard < Administrate::BaseDashboard
   COLLECTION_FILTERS = {
     golden: ->(resources) { resources.golden }
-  }
+  }.freeze
 
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.

--- a/app/models/receiver.rb
+++ b/app/models/receiver.rb
@@ -15,4 +15,6 @@ class Receiver < ApplicationRecord
     :matched_gifts
 
   validates :golden, inclusion: { in: [true, false] }
+
+  scope :golden, -> { where(golden: true) }
 end

--- a/app/views/admin/receivers/index.slim
+++ b/app/views/admin/receivers/index.slim
@@ -1,0 +1,38 @@
+- content_for(:title) do
+  = display_resource_name(page.resource_name)
+
+header.main-content__header role="banner"
+  h1#page-title.main-content__page-title
+    = content_for(:title)
+  - if show_search_bar
+    = render(                                                    \
+        "search",                                                \
+        search_term: search_term,                                \
+        resource_name: display_resource_name(page.resource_name) \
+      )
+
+  div style="margin-right: 10px"
+    = link_to(                                                                      \
+        "Display Goldens",                                                          \
+        request.params.merge(golden: true, authenticity_token: nil, _method: nil),  \
+        class: "button",                                                            \
+        method: :get                                                                \
+      )
+
+  div
+    = link_to(                                                                              \
+        t("administrate.actions.new_resource", name: page.resource_name.titleize.downcase), \
+        [:new, namespace, page.resource_path],                                              \
+        class: "button",                                                                    \
+      ) if valid_action? :new
+
+section.main-content__body.main-content__body--flush
+  = render(                                   \
+      "collection",                           \
+      collection_presenter: page,             \
+      resources: resources,                   \
+      table_title: "page-title",              \
+      page: page,                             \
+      collection_field_name: resource_name,   \
+    )
+  = paginate resources

--- a/app/views/admin/receivers/index.slim
+++ b/app/views/admin/receivers/index.slim
@@ -11,14 +11,6 @@ header.main-content__header role="banner"
         resource_name: display_resource_name(page.resource_name) \
       )
 
-  div style="margin-right: 10px"
-    = link_to(                                                                      \
-        "Display Goldens",                                                          \
-        request.params.merge(golden: true, authenticity_token: nil, _method: nil),  \
-        class: "button",                                                            \
-        method: :get                                                                \
-      )
-
   div
     = link_to(                                                                              \
         t("administrate.actions.new_resource", name: page.resource_name.titleize.downcase), \


### PR DESCRIPTION
This PR uses an administrate PR (currently open) that allows us to search scopes on the search bar. This way we can search by golden receivers using the search term `golden:`.