### PR TITLE
Refactor react_component helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
 
   # Shorthand helper for react components
   # Only use prerender in test and prod environments, even if it's set to true
-  def react_component_helper(component:, prerender: false)
+  def render_react_component(component:, prerender: false)
     react_component(component, nil, prerender: Rails.env.development? ? false : prerender)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,10 @@ module ApplicationHelper
       model.errors[attr].map(&:capitalize).join(". ")
     end
   end
+
+  # Shorthand helper for react components
+  # Only use prerender in test and prod environments, even if it's set to true
+  def react_component_helper(component:, prerender: false)
+    react_component(component, nil, prerender: Rails.env.development? ? false : prerender)
+  end
 end

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,6 +1,6 @@
-= react_component("Header", nil, { prerender: false })
+= react_component_helper(component: "Header", prerender: true)
 
-= react_component("HowItWorks", nil, { prerender: false })
+= react_component_helper(component: "HowItWorks", prerender: true)
 
 = render "timeline"
 

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,6 +1,6 @@
-= react_component_helper(component: "Header", prerender: true)
+= render_react_component(component: "Header", prerender: true)
 
-= react_component_helper(component: "HowItWorks", prerender: true)
+= render_react_component(component: "HowItWorks", prerender: true)
 
 = render "timeline"
 


### PR DESCRIPTION
This creates a new `react_component_helper` method that acts as a shortcut to the `react_component` helper. It also only allows prerendering (server side rendering) outside of the development environment, because it's hard to debug server side rendering using Rails.