### PR TITLE
Fix vulnerability in the loofah gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "administrate", github: "substancelab/administrate", branch: "276-collection
 gem "bootstrap-sass", "~> 3.2.0"
 gem "email_validator"
 gem "foreman"
+gem "loofah", ">= 2.2.3"
 gem "pg"
 gem "pry-rails"
 gem "puma", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -341,6 +341,7 @@ DEPENDENCIES
   letter_opener
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
+  loofah (>= 2.2.3)
   pg
   pry-rails
   pry-remote
@@ -369,4 +370,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
Why:

* According to GitHub alerts:

CVE-2018-16468 (moderate severity)

Vulnerable versions: < 2.2.3

Patched version: 2.2.3

In the Loofah gem for Ruby, through version 2.2.2, unsanitized
JavaScript may occur in sanitized output when a crafted SVG element is
republished. Users are advised to upgrade to version 2.2.3.

See flavorjones/loofah#154 for more details.

This change addresses the need by:

* Updating the loofah gem to version 2.2.3.