### PR TITLE
Send mail when match is made

### DIFF
--- a/app/mailers/match_mailer.rb
+++ b/app/mailers/match_mailer.rb
@@ -2,16 +2,10 @@ class MatchMailer < ApplicationMailer
   add_template_helper(ReceiverHelper)
   add_template_helper(UserHelper)
 
-  def match_ready(user)
-    @user = user
+  def match_redeemed(match)
+    @user = match.user
+    @receiver = match.receiver
 
-    mail to: user.email, subject: "[Secret Santa] A tua carta está pronta!"
-  end
-
-  def match_redeemed(user, receiver)
-    @user = user
-    @receiver = receiver
-
-    mail to: user.email, subject: "[Secret Santa] A tua carta está aqui!"
+    mail to: @user.email, subject: "[Secret Santa] A tua carta está aqui!"
   end
 end

--- a/app/services/match_assignment.rb
+++ b/app/services/match_assignment.rb
@@ -12,6 +12,7 @@ class MatchAssignment
 
       @receiver = available_receiver or rollback!("no receiver available")
       @match = create_match
+      send_match_email
 
       @success = true
     end
@@ -41,6 +42,10 @@ class MatchAssignment
     obfuscated_short_name = receiver.institution.obfuscated_short_name
 
     "#{receiver.id}#{obfuscated_short_name}#{user.id}"
+  end
+
+  def send_match_email
+    MatchMailer.match_redeemed(match).deliver_now
   end
 
   def rollback!(msg)

--- a/spec/flows/user_confirmation_spec.rb
+++ b/spec/flows/user_confirmation_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe UserConfirmationFlow, type: :model do
     end
 
     it "deletes the user and closes registrations if there are no receivers" do
+      enable_registrations
       user = create(:user, confirmed_at: nil)
       user_confirmation = UserConfirmationFlow.new(user.confirmation_token)
 


### PR DESCRIPTION
Why:

* Users could not write down the letter, so we must email it so they don't lose it

This change addresses the need by:

* Calling the MatchMailer from the MatchAssignmentService