### PR TITLE
Defer javascript for better page load time and set HTML lang attribute

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,10 +1,8 @@
 doctype html
-html
+html lang="pt"
   head
     title Secret Santa | Include Braga
     = csrf_meta_tags
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application'
     = stylesheet_pack_tag 'application', media: 'all'
     = favicon_link_tag
 
@@ -17,3 +15,5 @@ html
 
   body
     = yield
+
+  = javascript_pack_tag 'application', defer: true


### PR DESCRIPTION
Why:

* As all pages are server rendered, we don't need to block the page while we don't have React
* Improve accessibility

This change addresses the need by:

* Deferring the javascript_pack_tag to the bottom of the layout
* Setting the lang attribute