### PR TITLE
Add csv importer to add receivers to an institution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 ruby "2.5.1"
 
+gem "activerecord-import"
 gem "administrate", github: "substancelab/administrate", branch: "276-collection_filters"
 gem "bootstrap-sass", "~> 3.2.0"
 gem "email_validator"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       activemodel (= 5.2.1)
       activesupport (= 5.2.1)
       arel (>= 9.0)
+    activerecord-import (0.22.0)
+      activerecord (>= 3.2)
     activestorage (5.2.1)
       actionpack (= 5.2.1)
       activerecord (= 5.2.1)
@@ -325,6 +327,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   administrate!
   awesome_print
   better_errors

--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -1,12 +1,18 @@
 module Admin
   class InstitutionsController < Admin::ApplicationController
     def import_receivers
-      service = ImportReceiversFromCsv.new(path: params["file"].tempfile, institution_id: params[:institution_id])
+      service = ImportReceiversFromCSV.new(csv_params)
       service.perform
 
       flash[:notice] = "Imported #{service.imported_receivers} receivers with #{service.failed_receivers} failures!"
 
       redirect_to admin_institution_path(params[:institution_id])
+    end
+
+    private
+
+    def csv_params
+      { path: params["file"].tempfile, institution_id: params[:institution_id] }
     end
   end
 end

--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -1,4 +1,16 @@
 module Admin
   class InstitutionsController < Admin::ApplicationController
+    def import_receivers
+      institution = Institution.find(params[:id])
+      csv_file = params["file"].tempfile
+      csv_content = File.read(csv_file)
+      service = ImportReceiversFromCsv.new(csv_content, institution)
+
+      service.perform
+
+      flash[:notice] = "Imported #{service.imported_receivers} receivers with #{service.failed_receivers} failures!"
+
+      redirect_to admin_institution_path(institution)
+    end
   end
 end

--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -1,11 +1,7 @@
 module Admin
   class InstitutionsController < Admin::ApplicationController
     def import_receivers
-      institution = Institution.find(params[:id])
-      csv_file = params["file"].tempfile
-      csv_content = File.read(csv_file)
-      service = ImportReceiversFromCsv.new(csv_content, institution)
-
+      service = ImportReceiversFromCSV.new(path: params["file"].tempfile, institution_id: params[:id])
       service.perform
 
       flash[:notice] = "Imported #{service.imported_receivers} receivers with #{service.failed_receivers} failures!"

--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class InstitutionsController < Admin::ApplicationController
     def import_receivers
-      service = ImportReceiversFromCSV.new(path: params["file"].tempfile, institution_id: params[:id])
+      service = ImportReceiversFromCsv.new(path: params["file"].tempfile, institution_id: params[:institution_id])
       service.perform
 
       flash[:notice] = "Imported #{service.imported_receivers} receivers with #{service.failed_receivers} failures!"
 
-      redirect_to admin_institution_path(institution)
+      redirect_to admin_institution_path(params[:institution_id])
     end
   end
 end

--- a/app/services/import_receivers_from_csv.rb
+++ b/app/services/import_receivers_from_csv.rb
@@ -3,9 +3,9 @@ require "csv"
 class ImportReceiversFromCsv
   attr_reader :failed_receivers, :imported_receivers
 
-  def initialize(csv, institution)
-    @csv = csv
-    @institution = institution
+  def initialize(path:, institution_id:)
+    @csv_path = path
+    @institution_id = institution_id
     @receivers = []
     @success = false
     @failed_receivers = 0
@@ -26,19 +26,17 @@ class ImportReceiversFromCsv
 
   private
 
-  attr_reader :csv, :receivers, :institution, :success
+  attr_reader :csv_path, :receivers, :institution_id, :success
 
   def log_errors(receiver)
     Rails.logger.warn("Failed to save one of the models: #{receiver.errors.full_messages.join(' | ')}")
   end
 
   def build_receivers
-    CSV.parse(csv, headers: true) do |row|
-      receiver = Receiver.new(row.to_hash.merge(institution_id: institution.id))
+    CSV.foreach(csv_path, headers: true) do |row|
+      receiver = Receiver.new(row.to_hash.merge(institution_id: institution_id))
 
-      unless receiver.valid?
-        log_errors(receiver)
-      end
+      log_errors(receiver) unless receiver.valid?
 
       receivers << receiver
     end

--- a/app/services/import_receivers_from_csv.rb
+++ b/app/services/import_receivers_from_csv.rb
@@ -1,6 +1,6 @@
 require "csv"
 
-class ImportReceiversFromCsv
+class ImportReceiversFromCSV
   attr_reader :failed_receivers, :imported_receivers
 
   def initialize(path:, institution_id:)

--- a/app/services/import_receivers_from_csv.rb
+++ b/app/services/import_receivers_from_csv.rb
@@ -1,0 +1,53 @@
+require "csv"
+
+class ImportReceiversFromCsv
+  attr_reader :failed_receivers, :imported_receivers
+
+  def initialize(csv, institution)
+    @csv = csv
+    @institution = institution
+    @receivers = []
+    @success = false
+    @failed_receivers = 0
+    @imported_receivers = 0
+  end
+
+  def perform
+    build_receivers
+
+    import
+
+    @success = true
+  end
+
+  def successful?
+    success
+  end
+
+  private
+
+  attr_reader :csv, :receivers, :institution, :success
+
+  def log_errors(receiver)
+    Rails.logger.warn("Failed to save one of the models: #{receiver.errors.full_messages.join(' | ')}")
+  end
+
+  def build_receivers
+    CSV.parse(csv, headers: true) do |row|
+      receiver = Receiver.new(row.to_hash.merge(institution_id: institution.id))
+
+      unless receiver.valid?
+        log_errors(receiver)
+      end
+
+      receivers << receiver
+    end
+  end
+
+  def import
+    bulk_import = Receiver.import(receivers)
+
+    @failed_receivers = bulk_import.failed_instances.count
+    @imported_receivers = bulk_import.ids.count
+  end
+end

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -1,0 +1,77 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<script>
+window.onload = function(){
+  var val = document.getElementById("file").value;
+
+  if (!val){
+    document.getElementById("submit_file").disabled = true;
+  }
+}
+
+function enableButton(){
+    var val = document.getElementById("file").value;
+
+  if (val){
+    document.getElementById("submit_file").disabled = false;
+  }
+}
+
+</script>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div style="margin: 0 20px 0 20px">
+    <%= form_tag({action: :import_receivers}, multipart: true) do %>
+      <%= file_field_tag 'file', onchange: "enableButton()" %>
+      <div style="margin-top: 10px">
+        <%= submit_tag "Import receivers from csv", id: "submit_file" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute, page: page %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -43,7 +43,7 @@ function enableButton(){
   </h1>
 
   <div style="margin: 0 20px 0 20px">
-    <%= form_tag({action: :import_receivers}, multipart: true) do %>
+    <%= form_tag({action: :import_receivers, institution_id: page.resource.id}, multipart: true) do %>
       <%= file_field_tag 'file', onchange: "enableButton()" %>
       <div style="margin-top: 10px">
         <%= submit_tag "Import receivers from csv", id: "submit_file" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     post "/match/", to: "users#batch_match", as: :users_batch_match
     post "/receive/:id", to: "users#receive", as: :users_receive
     post "/revert/:id", to: "users#revert_receive", as: :users_revert
-    post "/import_receivers/:id", to: "institutions#import_receivers", as: :institutions_import_receivers
+    post "/institution/:institution_id/import_receivers", to: "institutions#import_receivers", as: :institutions_import_receivers
   end
 
   if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     post "/match/", to: "users#batch_match", as: :users_batch_match
     post "/receive/:id", to: "users#receive", as: :users_receive
     post "/revert/:id", to: "users#revert_receive", as: :users_revert
+    post "/import_receivers/:id", to: "institutions#import_receivers", as: :institutions_import_receivers
   end
 
   if Rails.env.development?

--- a/spec/fixtures/files/receivers.csv
+++ b/spec/fixtures/files/receivers.csv
@@ -1,0 +1,8 @@
+name,age,gender,letter
+RECEIVER1,16,male,"Gosto de cenas
+cenas is cool
+"
+RECEIVER2,20,female,"foo barzinos
+this is multiline
+AND IT WORKS
+"

--- a/spec/fixtures/files/receivers_bad.csv
+++ b/spec/fixtures/files/receivers_bad.csv
@@ -1,0 +1,8 @@
+name,age,gender,letter
+,16,male,"Gosto de cenas
+cenas is cool
+"
+,20,female,"foo barzinos
+this is multiline
+AND IT WORKS
+"

--- a/spec/fixtures/files/receivers_half_bad.csv
+++ b/spec/fixtures/files/receivers_half_bad.csv
@@ -1,0 +1,8 @@
+name,age,gender,letter
+Nome,16,male,"Gosto de cenas
+cenas is cool
+"
+,20,female,"foo barzinos
+this is multiline
+AND IT WORKS
+"

--- a/spec/services/import_receivers_from_csv_spec.rb
+++ b/spec/services/import_receivers_from_csv_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe ImportReceiversFromCsv, type: :model do
+  describe "#perform" do
+    it "imports one receivers with the given data" do
+      institution = create(:institution)
+      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers.csv"), institution)
+
+      service.perform
+      receiver = Receiver.first
+
+
+      expect(receiver.name).to eq("RECEIVER1")
+      expect(receiver.age).to eq(16)
+      expect(receiver.gender).to eq("male")
+      expect(receiver.letter).to eq("Gosto de cenas\ncenas is cool\n")
+    end
+
+    it "imports all receivers" do
+      institution = create(:institution)
+      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers.csv"), institution)
+
+      expect do
+        service.perform
+      end.to change { Receiver.count }.by(2)
+
+      expect(service).to be_successful
+      expect(service.imported_receivers).to eq(2)
+      expect(service.failed_receivers).to eq(0)
+    end
+
+    it "fails to import bad receivers" do
+      institution = create(:institution)
+      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers_bad.csv"), institution)
+
+      expect do
+        service.perform
+      end.to change { Receiver.count }.by(0)
+
+      expect(service).to be_successful
+      expect(service.imported_receivers).to eq(0)
+      expect(service.failed_receivers).to eq(2)
+    end
+
+    it "imports the good receivers and ignores the bad receivers" do
+      institution = create(:institution)
+      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers_half_bad.csv"), institution)
+
+      expect do
+        service.perform
+      end.to change { Receiver.count }.by(1)
+
+      expect(service).to be_successful
+      expect(service.imported_receivers).to eq(1)
+      expect(service.failed_receivers).to eq(1)
+    end
+  end
+
+  def csv_file_to_string(filename)
+    File.read(file_fixture(filename))
+  end
+end

--- a/spec/services/import_receivers_from_csv_spec.rb
+++ b/spec/services/import_receivers_from_csv_spec.rb
@@ -2,13 +2,12 @@ require "rails_helper"
 
 RSpec.describe ImportReceiversFromCsv, type: :model do
   describe "#perform" do
-    it "imports one receivers with the given data" do
+    it "imports one receiver with the given data" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers.csv"), institution)
+      service = ImportReceiversFromCsv.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
 
       service.perform
       receiver = Receiver.first
-
 
       expect(receiver.name).to eq("RECEIVER1")
       expect(receiver.age).to eq(16)
@@ -18,7 +17,7 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "imports all receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers.csv"), institution)
+      service = ImportReceiversFromCsv.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
 
       expect do
         service.perform
@@ -31,11 +30,11 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "fails to import bad receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers_bad.csv"), institution)
+      service = ImportReceiversFromCsv.new(path: file_fixture("receivers_bad.csv"), institution_id: institution.id)
 
       expect do
         service.perform
-      end.to change { Receiver.count }.by(0)
+      end.not_to change { Receiver.count }
 
       expect(service).to be_successful
       expect(service.imported_receivers).to eq(0)
@@ -44,7 +43,7 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "imports the good receivers and ignores the bad receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(csv_file_to_string("receivers_half_bad.csv"), institution)
+      service = ImportReceiversFromCsv.new(path: file_fixture("receivers_half_bad.csv"), institution_id: institution.id)
 
       expect do
         service.perform
@@ -54,9 +53,5 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
       expect(service.imported_receivers).to eq(1)
       expect(service.failed_receivers).to eq(1)
     end
-  end
-
-  def csv_file_to_string(filename)
-    File.read(file_fixture(filename))
   end
 end

--- a/spec/services/import_receivers_from_csv_spec.rb
+++ b/spec/services/import_receivers_from_csv_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe ImportReceiversFromCsv, type: :model do
+RSpec.describe ImportReceiversFromCSV, type: :model do
   describe "#perform" do
     it "imports one receiver with the given data" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
+      service = ImportReceiversFromCSV.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
 
       service.perform
       receiver = Receiver.first
@@ -17,7 +17,7 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "imports all receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
+      service = ImportReceiversFromCSV.new(path: file_fixture("receivers.csv"), institution_id: institution.id)
 
       expect do
         service.perform
@@ -30,7 +30,7 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "fails to import bad receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(path: file_fixture("receivers_bad.csv"), institution_id: institution.id)
+      service = ImportReceiversFromCSV.new(path: file_fixture("receivers_bad.csv"), institution_id: institution.id)
 
       expect do
         service.perform
@@ -43,7 +43,7 @@ RSpec.describe ImportReceiversFromCsv, type: :model do
 
     it "imports the good receivers and ignores the bad receivers" do
       institution = create(:institution)
-      service = ImportReceiversFromCsv.new(path: file_fixture("receivers_half_bad.csv"), institution_id: institution.id)
+      service = ImportReceiversFromCSV.new(path: file_fixture("receivers_half_bad.csv"), institution_id: institution.id)
 
       expect do
         service.perform


### PR DESCRIPTION
Why:

* We needed a quick way to add receivers from a Google Drive Sheet to the application

This change addresses the need by:

* Adding a service that parses a CSV file with receivers and adds them to an Institution
* Adding a mini-form to the Institution admin show page, to import receivers to the selected insititution