### PR TITLE
Add receive/not_received filters to Matches and button to mark as received

### DIFF
--- a/app/controllers/admin/matches_controller.rb
+++ b/app/controllers/admin/matches_controller.rb
@@ -1,4 +1,12 @@
 module Admin
   class MatchesController < Admin::ApplicationController
+    def received
+      match = Match.find(params[:match_id])
+      match.update(received: true)
+
+      flash[:notice] = "Match marked as received!"
+
+      redirect_to admin_matches_path
+    end
   end
 end

--- a/app/dashboards/match_dashboard.rb
+++ b/app/dashboards/match_dashboard.rb
@@ -1,6 +1,11 @@
 require "administrate/base_dashboard"
 
 class MatchDashboard < Administrate::BaseDashboard
+  COLLECTION_FILTERS = {
+    received: ->(resources) { resources.received },
+    not_received: ->(resources) { !resources.received }
+  }.freeze
+
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -26,6 +31,7 @@ class MatchDashboard < Administrate::BaseDashboard
     user
     receiver
     code
+    received
     created_at
   ].freeze
 
@@ -47,6 +53,7 @@ class MatchDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     user
     receiver
+    received
   ].freeze
 
   # Overwrite this method to customize how matches are displayed

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -10,6 +10,9 @@ class Match < ApplicationRecord
   validates :receiver_id, presence: true
   validates :received, inclusion: { in: [true, false] }
 
+  scope :received, -> { where(received: true) }
+  scope :not_received, -> { where(received: false) }
+
   def received?
     received
   end

--- a/app/views/admin/matches/_collection.html.erb
+++ b/app/views/admin/matches/_collection.html.erb
@@ -1,0 +1,100 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [true, valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          tabindex="0"
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if show_action? :show, resource -%>
+              <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% end -%>
+          </td>
+        <% end %>
+
+
+        <td>
+          <%= button_to("Set Received", admin_match_received_path(match_id: resource.id), disabled: resource.received) %>
+        </td>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource],
+            class: "action-edit",
+          ) if show_action? :edit, resource%></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, resource],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :destroy, resource %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/confirmations/create.slim
+++ b/app/views/users/confirmations/create.slim
@@ -1,1 +1,1 @@
-= render_react_component(component: "ConfirmationsCreate", props: { username: @user.name, letter: letter_html(@receiver) }, prerender: true)
+= render_react_component(component: "ConfirmationsCreate", props: { username: @user.name, letter: convert_line_breaks_to_html(@receiver) }, prerender: true)

--- a/app/views/users/confirmations/create.slim
+++ b/app/views/users/confirmations/create.slim
@@ -1,2 +1,1 @@
-= render_react_component(component: "ConfirmationsCreate", props: { username: @user.name, letter: convert_line_breaks_to_html(@receiver) }, prerender: true)
-
+= render_react_component(component: "ConfirmationsCreate", props: { username: @user.name, letter: letter_html(@receiver) }, prerender: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     post "/receive/:id", to: "users#receive", as: :users_receive
     post "/revert/:id", to: "users#revert_receive", as: :users_revert
     post "/institution/:institution_id/import_receivers", to: "institutions#import_receivers", as: :institutions_import_receivers
+    post "/match/:match_id/received", to: "matches#received", as: :match_received
   end
 
   if Rails.env.development?

--- a/frontend/components/Header/index.css
+++ b/frontend/components/Header/index.css
@@ -66,7 +66,7 @@
   }
 
   @include Breakpoint-mobileOnly {
-    flex-direction: column;
+    flex-direction: column-reverse;
     margin-right: $gutter;
     margin-left: auto;
 
@@ -110,7 +110,8 @@
   @include Breakpoint-mobileOnly {
     margin-left: 0;
 
-    line-height: $line-height-large;
+    font-size: $font-size-medium;
+    line-height: $line-height-medium;
   }
 }
 

--- a/frontend/components/Header/index.css
+++ b/frontend/components/Header/index.css
@@ -66,7 +66,7 @@
   }
 
   @include Breakpoint-mobileOnly {
-    flex-direction: column-reverse;
+    flex-direction: column;
     margin-right: $gutter;
     margin-left: auto;
 
@@ -110,8 +110,7 @@
   @include Breakpoint-mobileOnly {
     margin-left: 0;
 
-    font-size: $font-size-medium;
-    line-height: $line-height-medium;
+    line-height: $line-height-large;
   }
 }
 


### PR DESCRIPTION
Why:

* We need better usability on the Matches dashboard
* Need to filter received AND not_received Matches

This change addresses the need by:

* Creating 2 scopes to enable search by scope `received:` and `not_received:`
* Adding button and controller action to just enable one single match