### PR TITLE
Refactor FrontPage

### DIFF
--- a/frontend/components/Header/index.css
+++ b/frontend/components/Header/index.css
@@ -33,7 +33,7 @@
 
 .content {
   @include Breakpoint-tabletAndAbove {
-    max-width: $content-width;
+    max-width: $inner-content;
 
     margin: 0 auto;
   }
@@ -42,11 +42,10 @@
 }
 
 .the-impossible {
-  margin-top: calc(2 * $spacing-xxxLarge);
-  margin-left: $column-spacing;
+  margin-top: $spacing-224;
 
   @include Breakpoint-tabletAndBelow {
-    margin-top: $spacing-xxxLarge;
+    margin-top: $spacing-112;
     margin-left: $gutter;
   }
 }
@@ -54,43 +53,26 @@
 .secret-santa {
   display: flex;
   flex-direction: row;
+  align-items: baseline;
 
-  margin-top: $spacing-xxxxLarge;
-  margin-bottom: $spacing-xxxLarge;
-  margin-left: $five-columns;
+  margin-top: 197px;
+  margin-bottom: 142px;
+  margin-left: calc($three-columns + $gutter);
 
   text-align: left;
 
   @include Breakpoint-tabletOnly {
-    margin-left: $four-columns;
+    align-items: stretch;
+    margin-left: calc($two-columns + $gutter);
   }
 
   @include Breakpoint-mobileOnly {
     flex-direction: column;
-    margin-right: $gutter;
+    align-items: stretch;
+    margin-right: calc($column + $gutter);
     margin-left: auto;
 
     text-align: right;
-  }
-}
-
-.with-underline {
-  background-image: url("../../assets/underline.svg");
-  background-position: 50% 100%;
-  background-repeat: no-repeat;
-  background-size: auto 16px;
-
-  @include Breakpoint-tabletOnly {
-    background-size: auto 11px;
-  }
-
-  @include Breakpoint-mobileOnly {
-    background-position: bottom right;
-    background-size: auto 8px;
-  }
-
-  h2 {
-    margin-bottom: $spacing-xxxSmall;
   }
 }
 
@@ -108,6 +90,7 @@
   }
 
   @include Breakpoint-mobileOnly {
+    margin-top: $spacing-8;
     margin-left: 0;
 
     line-height: $line-height-large;
@@ -133,22 +116,15 @@
 .a-year-ago {
   display: flex;
   flex-direction: column;
-
   max-width: $three-columns;
-
-  margin-top: $spacing-xxxLarge;
-  margin-bottom: $spacing-xxxLarge;
-  margin-left: $gutter;
+  margin: 57px 0 187px $gutter;
 
   @include Breakpoint-tabletAndAbove {
     max-width: $five-columns;
-
-    margin-top: $spacing-xxxLarge;
-    margin-bottom: calc(2 * $spacing-xxxLarge);
-    margin-left: $column-spacing;
+    margin: $spacing-112 0 calc(2 * $spacing-112);
   }
 }
 
 .a-year-ago > *:not(:last-child) {
-  padding-bottom: $spacing-medium;
+  padding-bottom: $spacing-28;
 }

--- a/frontend/components/Header/index.js
+++ b/frontend/components/Header/index.js
@@ -12,18 +12,13 @@ const Header = () => (
       <div styleName="the-impossible">
         <Heading weight="bold">o impossível acontece.</Heading>
       </div>
-
       <div styleName="secret-santa">
-        <div styleName="with-underline">
-          <Heading level="2" weight="bold">
-            secret santa
-          </Heading>
-        </div>
+        <Heading level="2" weight="bold" underline>
+          secret santa
+        </Heading>
         <div styleName="include">#include &lt;braga&gt;</div>
       </div>
-
       <Separator />
-
       <div styleName="a-year-ago">
         <Text weight="bold">
           há um ano ajudamos mais de 160 crianças e idosos a passar um Natal

--- a/frontend/components/Heading/index.css
+++ b/frontend/components/Heading/index.css
@@ -1,7 +1,10 @@
-@import "../../styles/typography.css";
-@import "../../styles/breakpoints.css";
+@import '../../styles/typography.css';
+@import '../../styles/breakpoints.css';
+@import '../../styles/layout.css';
 
 .root {
+  position: relative;
+
   color: white;
 }
 
@@ -76,4 +79,34 @@
 
 .black {
   color: black;
+}
+
+.underline::after {
+  content: '';
+
+  position: absolute;
+
+  bottom: -8px;
+  left: 0;
+
+  width: 100%;
+  height: 16px;
+
+  background-image: url('../../assets/underline.svg');
+  background-position: 50% 100%;
+  background-repeat: no-repeat;
+  background-size: auto 16px;
+
+  @include Breakpoint-tabletOnly {
+    height: 11px;
+
+    background-size: auto 11px;
+  }
+
+  @include Breakpoint-mobileOnly {
+    height: 8px;
+
+    background-position: bottom right;
+    background-size: auto 8px;
+  }
 }

--- a/frontend/components/Heading/index.js
+++ b/frontend/components/Heading/index.js
@@ -11,6 +11,7 @@ export default class Heading extends React.Component {
     color: PropTypes.oneOf(['black', 'white']),
     level: PropTypes.oneOf(['1', '2', '3']),
     weight: PropTypes.oneOf(['regular', 'bold', 'italic']),
+    underline: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -18,16 +19,26 @@ export default class Heading extends React.Component {
     color: 'white',
     level: '1',
     weight: 'regular',
+    underline: false,
   };
 
   render() {
-    const { children, level, fontFamily, color, weight } = this.props;
+    const {
+      children,
+      level,
+      fontFamily,
+      color,
+      weight,
+      underline,
+    } = this.props;
     const styles = classNames('root', {
       [`level${level}`]: true,
       [fontFamily]: true,
       [color]: true,
       [weight]: true,
+      underline,
     });
+
     const HeadingComponent = `h${level}`;
 
     return <HeadingComponent styleName={styles}>{children}</HeadingComponent>;

--- a/frontend/components/Layout/index.css
+++ b/frontend/components/Layout/index.css
@@ -5,10 +5,10 @@
   @include Breakpoint-desktopOnly {
     max-width: $content-width;
 
-    margin: $spacing-xxxLarge auto $spacing-xxxLarge auto;
+    margin: $spacing-112 auto $spacing-112 auto;
   }
 
   @include Breakpoint-tabletAndBelow {
-    margin: $spacing-xxLarge $gutter $spacing-xxLarge $gutter;
+    margin: $spacing-84 $gutter $spacing-84 $gutter;
   }
 }

--- a/frontend/components/Separator/index.css
+++ b/frontend/components/Separator/index.css
@@ -5,7 +5,7 @@ $circle-size: 50px;
 $line-size: 1px;
 
 @mixin white-line {
-  width: $seven-columns;
+  width: calc($five-columns - $circle-size);
   height: $line-size;
 
   background-color: #fafafa;
@@ -13,7 +13,7 @@ $line-size: 1px;
   border: solid calc($line-size / 2) #fafafa;
 
   @include Breakpoint-tabletOnly {
-    width: $six-columns;
+    width: calc($four-columns - $circle-size);
   }
 
   @include Breakpoint-mobileOnly {
@@ -35,16 +35,21 @@ $line-size: 1px;
   width: 50%;
 }
 
-.line {
-  @include white-line;
-}
-
 .circle {
   width: $circle-size;
   height: $circle-size;
 
   margin-top: calc(($circle-size / -2) + 1px);
+  margin-left: calc($five-columns - $circle-size);
 
   background-color: white;
   border-radius: 50%;
+
+  @include Breakpoint-tabletOnly {
+    margin-left: calc($four-columns - $circle-size);
+  }
+
+  @include Breakpoint-mobileOnly {
+    margin-left: calc(50% - $circle-size);
+  }
 }

--- a/frontend/components/Separator/index.js
+++ b/frontend/components/Separator/index.js
@@ -5,7 +5,6 @@ import './index.css';
 const Separator = () => (
   <div styleName="root">
     <div styleName="absolute-line" />
-    <div styleName="line" />
     <div styleName="circle" />
   </div>
 );

--- a/frontend/pages/ConfirmationsClosed/index.css
+++ b/frontend/pages/ConfirmationsClosed/index.css
@@ -13,9 +13,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: $spacing-medium;
+  margin-top: $spacing-28;
 }
 
 .text > *:not(:last-child) {
-  margin-bottom: $spacing-medium;
+  margin-bottom: $spacing-28;
 }

--- a/frontend/pages/ConfirmationsCreate/index.css
+++ b/frontend/pages/ConfirmationsCreate/index.css
@@ -14,18 +14,18 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: $spacing-xLarge;
-  margin-top: $spacing-medium;
+  padding-bottom: $spacing-56;
+  margin-top: $spacing-28;
 
   border-bottom: 2px solid black;
 }
 
 .text > *:not(:last-child) {
-  margin-bottom: $spacing-medium;
+  margin-bottom: $spacing-28;
 }
 
 .letter {
-  margin-top: $spacing-xLarge;
+  margin-top: $spacing-56;
 
   @include default-styles;
 }

--- a/frontend/styles/layout.css
+++ b/frontend/styles/layout.css
@@ -1,21 +1,23 @@
 $column: 73px;
-$gutter: 28px;
+$gutter: 47px;
 $column-spacing: calc($column + 2 * $gutter);
 
-$content-width: calc(12 * $column + 11 * $gutter);
+$content-width: calc(12 * $column + 12 * $gutter);
+$inner-content: calc(10 * $column + 9 * $gutter);
 $min-content-width: 320px;
 
-$spacing-xxxxSmall: 4px;
-$spacing-xxxSmall: 8px;
-$spacing-xxSmall: 16px;
-$spacing-xSmall: 20px;
-$spacing-small: 24px;
-$spacing-medium: 28px;
-$spacing-large: 40px;
-$spacing-xLarge: 56px;
-$spacing-xxLarge: 84px;
-$spacing-xxxLarge: 112px;
-$spacing-xxxxLarge: 168px;
+$spacing-4: 4px;
+$spacing-8: 8px;
+$spacing-16: 16px;
+$spacing-20: 20px;
+$spacing-24: 24px;
+$spacing-28: 28px;
+$spacing-40: 40px;
+$spacing-56: 56px;
+$spacing-84: 84px;
+$spacing-112: 112px;
+$spacing-168: 168px;
+$spacing-224: 224px;
 
 $two-columns: calc(2 * $column + $gutter);
 $three-columns: calc(3 * $column + 2 * $gutter);


### PR DESCRIPTION
* Refactors Underline, so it can be reused easily as part of the header
* Refactors content width organization: we know that the content is only 
inside the 10 rows grid, so the other 2 are extra. Therefore, it is 
easier if we just focus on managing content inside the 10 rows grid 
(inner grid)
* Removes unnused extra line from the separator
* Refactors spacings so they're more readable, as this is a new scale 
for the majority of us and it doesn't make sense to have to constantly 
check the measures. This way is much simpler
* Adjust margins according to zeplin
