### PR TITLE
Log admin accesses

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_action :authenticate_admin
+    before_action :authenticate_admin, :log_access
 
     def records_per_page
       params[:per_page] || 50
@@ -16,6 +16,10 @@ module Admin
       authenticate_or_request_with_http_basic do |username, password|
         ENV["BASIC_AUTH"].split(":") == [username, password]
       end
+    end
+
+    def log_access
+      Rails.logger.info("Admin dashboard accessed from #{request.remote_ip}") unless Rails.env.development?
     end
   end
 end


### PR DESCRIPTION
Why:

* Due to GDPR, we need to know who accesses sensitive information at a given time

This change addresses the need by:

* Logging the remote IP of every request made to the `Administrate` controllers