### PR TITLE
Replace toggle_registration with concurrent safe alternative

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -117,14 +117,14 @@ module Admin
       redirect_to admin_user_path(user)
     end
 
-    def toggle_registrations
-      registrations_enabled = Settings.toggle_registrations
+    def set_registrations
+      registrations_enabled = ActiveRecord::Type::Boolean.new.cast(params[:value])
 
-      flash[:notice] = if registrations_enabled
-                         "User registrations enabled!"
-                       else
-                         "User registrations disabled!"
-                       end
+      return if registrations_enabled.nil?
+
+      Settings.put(:REGISTRATIONS_ENABLED, registrations_enabled)
+
+      flash[:notice] = registrations_enabled ? "User registrations enabled!" : "User registrations disabled!"
 
       redirect_to admin_users_path
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -38,87 +38,8 @@ module Admin
       redirect_to admin_users_path
     end
 
-    def assign
-      user = User.find(params[:id])
-      redeem_token_allocation = RedeemTokenAllocation.new([user])
-      redeem_token_allocation.perform
-
-      if redeem_token_allocation.updated_users == 1
-        flash[:notice] = "Redeem token assigned!"
-      else
-        flash[:error] = "Something went wrong, token was not assigned"
-      end
-
-      redirect_to admin_user_path(user)
-    end
-
-    def batch_assign
-      redeem_token_allocation = RedeemTokenAllocation.new
-      redeem_token_allocation.perform
-
-      nr_users = redeem_token_allocation.updated_users
-      flash[:notice] = "Assigned a redeem token to #{nr_users} users"
-
-      redirect_to admin_users_path
-    end
-
-    def match
-      user = User.find(params[:id])
-      match_notification = MatchNotification.new(user, force_resend: true)
-
-      match_notification.perform
-
-      if match_notification.successful?
-        flash[:notice] = "Sent the match notification"
-      else
-        flash[:error] = "Something went wrong. Maybe the user doesn't have a redeem token?"
-      end
-
-      redirect_to admin_user_path(user)
-    end
-
-    def batch_match
-      match_notification = BatchMatchNotification.new
-      match_notification.perform
-
-      nr_users = match_notification.notifications_sent
-      flash[:notice] = "Notified #{nr_users} users"
-
-      redirect_to admin_users_path
-    end
-
-    def receive
-      user = User.find(params[:id])
-      gift_reception = GiftReception.new(user)
-
-      gift_reception.perform
-
-      if gift_reception.successful?
-        flash[:notice] = "Gift received!"
-      else
-        flash[:error] - "Something went wrong. Maybe the user has no matches?"
-      end
-
-      redirect_to admin_user_path(user)
-    end
-
-    def revert_receive
-      user = User.find(params[:id])
-      gift_reception_reversion = GiftReceptionReversion.new(user)
-
-      gift_reception_reversion.perform
-
-      if gift_reception_reversion.successful?
-        flash[:notice] = "Gift reception reverted!"
-      else
-        flash[:error] - "Something went wrong. Maybe the user has no matches?"
-      end
-
-      redirect_to admin_user_path(user)
-    end
-
     def set_registrations
-      registrations_enabled = ActiveRecord::Type::Boolean.new.cast(params[:value])
+      registrations_enabled = registrations_enabled_param
 
       return if registrations_enabled.nil?
 
@@ -133,6 +54,10 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :email, :observations)
+    end
+
+    def registrations_enabled_param
+      ActiveRecord::Type::Boolean.new.cast(params[:value])
     end
   end
 end

--- a/app/flows/user_confirmation_flow.rb
+++ b/app/flows/user_confirmation_flow.rb
@@ -46,7 +46,7 @@ class UserConfirmationFlow
     match_assignment = MatchAssignment.new(user)
     match_assignment.perform
 
-    Settings.put(Settings::REGISTRATIONS_ENABLED, false) if Match.count == Receiver.count
+    Settings.put(:REGISTRATIONS_ENABLED, false) if Match.count == Receiver.count
 
     match_assignment.receiver if match_assignment.successful?
   end
@@ -54,7 +54,7 @@ class UserConfirmationFlow
   def cleanup
     user&.destroy
 
-    Settings.put(Settings::REGISTRATIONS_ENABLED, false)
+    Settings.put(:REGISTRATIONS_ENABLED, false)
   end
 
   def rollback!(msg, cleanup: false)

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -8,20 +8,6 @@ class Settings < ApplicationRecord
     Settings.find_by(key: REGISTRATIONS_ENABLED)&.value == "true" || false
   end
 
-  def self.toggle_registrations
-    registrations_enabled = Settings.find_or_initialize_by(key: REGISTRATIONS_ENABLED)
-
-    registrations_enabled.value = case registrations_enabled.value
-                                  when nil, "false"
-                                    "true"
-                                  when "true"
-                                    "false"
-                                  end
-    registrations_enabled.save
-
-    registrations_enabled.value == "true"
-  end
-
   def self.get(key)
     Settings.find_by(key: key)
   end

--- a/app/views/admin/users/index.slim
+++ b/app/views/admin/users/index.slim
@@ -26,25 +26,9 @@ header.main-content__header role="banner"
       )
 
   div style="margin-left: 10px"
-    = link_to(                                                                      \
-        "Send match emails",                                                        \
-        admin_users_batch_match_path,                                               \
-        class: "button",                                                            \
-        method: :post                                                               \
-      )
-
-  div style="margin-left: 10px"
-    = link_to(                                                                      \
-        "Assign redeem tokens",                                                     \
-        admin_users_batch_assign_path,                                              \
-        class: "button",                                                            \
-        method: :post                                                               \
-      )
-
-  div style="margin-left: 10px"
     = link_to(                                                                              \
-        Settings.registrations_enabled? ? "Disable registrations" : "Enable registrations", \
-        admin_users_set_registrations_path(value: !Settings.registrations_enabled?),        \
+        @registrations_enabled ? "Disable registrations" : "Enable registrations", \
+        admin_users_set_registrations_path(value: !@registrations_enabled),        \
         class: "button",                                                                    \
         method: :post                                                                       \
       )

--- a/app/views/admin/users/index.slim
+++ b/app/views/admin/users/index.slim
@@ -42,11 +42,11 @@ header.main-content__header role="banner"
       )
 
   div style="margin-left: 10px"
-    = link_to(                                                                             \
+    = link_to(                                                                              \
         Settings.registrations_enabled? ? "Disable registrations" : "Enable registrations", \
-        admin_users_toggle_registrations_path,                                             \
-        class: "button",                                                                   \
-        method: :post                                                                      \
+        admin_users_set_registrations_path(value: !Settings.registrations_enabled?),        \
+        class: "button",                                                                    \
+        method: :post                                                                       \
       )
 
 section.main-content__body.main-content__body--flush

--- a/app/views/admin/users/show.slim
+++ b/app/views/admin/users/show.slim
@@ -9,36 +9,10 @@ header.main-content__header[role="banner"]
         class: "button")
 
   div style="margin-left: 10px"
-    = link_to("Assign redeem token",
-          admin_users_assign_path(page.resource.id),
-          class: "button",
-          method: :post)
-
-  div style="margin-left: 10px"
-    = link_to("Resend Email",
+    = link_to("Resend Confirmation Email",
           admin_users_confirmation_path(page.resource.id),
           class: "button",
           method: :post)
-
-  div style="margin-left: 10px"
-    = link_to("Resend Match Link",
-          admin_users_match_path(page.resource.id),
-          class: "button",
-          method: :post)
-
-  / I'm so sorry for the next line
-  - if page.resource.matches.first&.received?
-    div style="margin-left: 10px"
-      = link_to("Revert receive",
-            admin_users_revert_path(page.resource.id),
-            class: "button danger",
-            method: :post)
-  - else
-    div style="margin-left: 10px"
-      = link_to("Receive gift",
-            admin_users_receive_path(page.resource.id),
-            class: "button success",
-            method: :post)
 
 section.main-content__body
   dl

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,13 +20,7 @@ Rails.application.routes.draw do
   namespace :admin do
     post "/confirm/:id", to: "users#confirm", as: :users_confirmation
     post "/confirm/", to: "users#batch_confirm", as: :users_batch_confirmation
-    post "/assign/:id", to: "users#assign", as: :users_assign
-    post "/assign", to: "users#batch_assign", as: :users_batch_assign
     post "/set_registrations", to: "users#set_registrations", as: :users_set_registrations
-    post "/match/:id", to: "users#match", as: :users_match
-    post "/match/", to: "users#batch_match", as: :users_batch_match
-    post "/receive/:id", to: "users#receive", as: :users_receive
-    post "/revert/:id", to: "users#revert_receive", as: :users_revert
     post "/institution/:institution_id/import_receivers", to: "institutions#import_receivers", as: :institutions_import_receivers
     post "/match/:match_id/received", to: "matches#received", as: :match_received
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     post "/confirm/", to: "users#batch_confirm", as: :users_batch_confirmation
     post "/assign/:id", to: "users#assign", as: :users_assign
     post "/assign", to: "users#batch_assign", as: :users_batch_assign
-    post "/toggle_registrations", to: "users#toggle_registrations", as: :users_toggle_registrations
+    post "/set_registrations", to: "users#set_registrations", as: :users_set_registrations
     post "/match/:id", to: "users#match", as: :users_match
     post "/match/", to: "users#batch_match", as: :users_batch_match
     post "/receive/:id", to: "users#receive", as: :users_receive

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Users::ConfirmationsController, type: :controller do
-  before(:each) { Settings.put(Settings::REGISTRATIONS_ENABLED, true) }
+  before(:each) { Settings.put(:REGISTRATIONS_ENABLED, true) }
 
   describe "GET #create" do
     context "with a valid token" do

--- a/spec/flows/user_confirmation_spec.rb
+++ b/spec/flows/user_confirmation_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe UserConfirmationFlow, type: :model do
   end
 
   def enable_registrations
-    Settings.put(Settings::REGISTRATIONS_ENABLED, true)
+    Settings.put(:REGISTRATIONS_ENABLED, true)
   end
 
   def disable_registrations
-    Settings.put(Settings::REGISTRATIONS_ENABLED, false)
+    Settings.put(:REGISTRATIONS_ENABLED, false)
   end
 end

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -7,28 +7,4 @@ RSpec.describe Settings, type: :model do
   it { should validate_presence_of(:value) }
 
   it { should validate_uniqueness_of(:key) }
-
-  it "should create a settings record if toggled for the first time" do
-    expect do
-      Settings.toggle_registrations
-    end.to change { Settings.count }.by(1)
-  end
-
-  it "should not create additional settings record if toggled more than once" do
-    Settings.toggle_registrations
-
-    expect do
-      Settings.toggle_registrations
-    end.not_to change { Settings.count }
-  end
-
-  it "should activate registration if toggled for the first time" do
-    expect(Settings.toggle_registrations).to be
-  end
-
-  it "should deactivate registrations if it's already activated" do
-    Settings.toggle_registrations
-
-    expect(Settings.toggle_registrations).not_to be
-  end
 end


### PR DESCRIPTION
Why:

* The toggle registrations method was based on the value in the database, so if two users click at the same time the second toggle would cancel the first, even though they probably wanted to do the same operation

This change addresses the need by:

* Make this toggle "frontend based", where the value that the button sends to the backend is based on the value returned from the server when the page is rendered, so if the button says "Enable Registrations" it will always enable, and if it says "Disable registrations" it will always disable.

ALSO: Deletes a bunch of unused actions from the admin/user_controller