### PR TITLE
Add a progress update rake task that posts to Slack

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,8 @@
 # export MAILER_DOMAIN=""
 # export RAVEN_DSN=""
 # export SECRET_KEY_BASE=""
-# export SLACK_TOKEN="your-slack-token"
+# export SLACK_TOKEN=""
+# export SLACK_INCOMING_WEBHOOK=""
 
 export MAILER_FROM_EMAIL="noreply@includebraga.org"
 export MAILER_FROM_NAME="Secret Santa Development"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "administrate", github: "substancelab/administrate", branch: "276-collection
 gem "bootstrap-sass", "~> 3.2.0"
 gem "email_validator"
 gem "foreman"
+gem "httparty"
 gem "loofah", ">= 2.2.3"
 gem "pg"
 gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       thor (>= 0.13.6)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
@@ -162,6 +164,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     msgpack (1.1.0)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.8.5)
@@ -341,6 +344,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  httparty
   letter_opener
   letter_opener_web
   listen (>= 3.0.5, < 3.2)

--- a/app/services/slack/message_delivery.rb
+++ b/app/services/slack/message_delivery.rb
@@ -1,0 +1,31 @@
+class Slack::MessageDelivery
+  INCOMING_WEBHOOK = ENV["SLACK_INCOMING_WEBHOOK"].freeze
+
+  def initialize(message)
+    @message = message
+    @successful = false
+  end
+
+  def perform
+    return unless Settings.registrations_enabled?
+
+    response = post_to_slack
+    @successful = response.code == 200
+  end
+
+  def successful?
+    @successful
+  end
+
+  private
+
+  attr_reader :message
+
+  def post_to_slack
+    HTTParty.post(
+      INCOMING_WEBHOOK,
+      headers: { "Content-Type" => "application/json" },
+      body: { text: message }.to_json,
+    )
+  end
+end

--- a/app/services/slack/message_router.rb
+++ b/app/services/slack/message_router.rb
@@ -30,16 +30,10 @@ class Slack::MessageRouter
   attr_reader :command, :args, :successful
 
   def stats
-    analytics = Analytics.build
+    progress_update = Slack::ProgressUpdate.new
+    progress_update.perform
 
-    [
-      "Gifts Received - #{analytics.gifts_received}",
-      "Gifts Missing - #{analytics.gifts_missing}",
-      "Gifts Matched - #{analytics.gifts_matched}",
-      "Normal Receivers - #{analytics.normal_receivers}",
-      "Golden Receivers - #{analytics.golden_receivers}",
-      "Total Receivers - #{analytics.total_receivers}",
-    ].join("\n")
+    progress_update.reply
   end
 
   def known_command?

--- a/app/services/slack/progress_update.rb
+++ b/app/services/slack/progress_update.rb
@@ -1,0 +1,30 @@
+class Slack::ProgressUpdate
+  def initialize
+    @successful = false
+  end
+
+  def perform
+    @analytics ||= Analytics.build
+
+    @successful = true
+  end
+
+  def successful?
+    @successful
+  end
+
+  def reply
+    @_reply ||= [
+      "Gifts Received - #{analytics.gifts_received}",
+      "Gifts Missing - #{analytics.gifts_missing}",
+      "Gifts Matched - #{analytics.gifts_matched}",
+      "Normal Receivers - #{analytics.normal_receivers}",
+      "Golden Receivers - #{analytics.golden_receivers}",
+      "Total Receivers - #{analytics.total_receivers}",
+    ].join("\n")
+  end
+
+  private
+
+  attr_reader :analytics
+end

--- a/lib/tasks/slack.rake
+++ b/lib/tasks/slack.rake
@@ -1,0 +1,8 @@
+namespace :slack do
+  task progress: :environment do
+    progress_update = Slack::ProgressUpdate.new
+    progress_update.perform
+
+    Slack::MessageDelivery.new(progress_update.reply).perform
+  end
+end

--- a/spec/services/slack/message_delivery_spec.rb
+++ b/spec/services/slack/message_delivery_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Slack::MessageDelivery, type: :model do
+  describe "#perform" do
+    before(:each) do
+      mock_slack_post
+      enable_registrations
+    end
+
+    it "is successful" do
+      message_delivery = Slack::MessageDelivery.new("message")
+
+      message_delivery.perform
+
+      expect(message_delivery).to be_successful
+    end
+
+    it "is unsuccessful if the registrations are disabled" do
+      disable_registrations
+      message_delivery = Slack::MessageDelivery.new("message")
+
+      message_delivery.perform
+
+      expect(message_delivery).not_to be_successful
+    end
+
+    it "posts to slack" do
+      expect(HTTParty).to receive(:post)
+      message_delivery = Slack::MessageDelivery.new("message")
+
+      message_delivery.perform
+
+      expect(message_delivery).to be_successful
+    end
+
+    it "is unsuccessful if the response code is not 200" do
+      mock_slack_post(500)
+      message_delivery = Slack::MessageDelivery.new("message")
+
+      message_delivery.perform
+
+      expect(message_delivery).not_to be_successful
+    end
+
+    def mock_slack_post(code = 200)
+      allow(HTTParty).to receive(:post).and_return(OpenStruct.new(code: code))
+    end
+
+    def enable_registrations
+      Settings.put(Settings::REGISTRATIONS_ENABLED, true)
+    end
+
+    def disable_registrations
+      Settings.put(Settings::REGISTRATIONS_ENABLED, false)
+    end
+  end
+end

--- a/spec/services/slack/message_router_spec.rb
+++ b/spec/services/slack/message_router_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 RSpec.describe Slack::MessageRouter, type: :model do
   describe "#perform" do
     it "is successful if the command is known" do
+      progress_update = mock_progress_update
       router = Slack::MessageRouter.new(text: "santa stats")
+      expect(progress_update).to receive(:perform)
+      expect(progress_update).to receive(:reply)
 
       router.perform
 
@@ -24,6 +27,15 @@ RSpec.describe Slack::MessageRouter, type: :model do
       router.perform
 
       expect(router.reply).to eq(Slack::MessageRouter::DEFAULT_RESPONSE)
+    end
+
+    def mock_progress_update
+      progress_update = double(:progress_update)
+      allow(progress_update).to receive(:perform)
+      allow(progress_update).to receive(:reply)
+      allow(Slack::ProgressUpdate).to receive(:new).and_return(progress_update)
+
+      progress_update
     end
   end
 end

--- a/spec/services/slack/progress_update_spec.rb
+++ b/spec/services/slack/progress_update_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Slack::ProgressUpdate, type: :model do
+  describe "#perform" do
+    it "is successful" do
+      progress_update = Slack::ProgressUpdate.new
+
+      progress_update.perform
+
+      expect(progress_update).to be_successful
+    end
+
+    it "builds the current analytics" do
+      progress_update = Slack::ProgressUpdate.new
+      expect(Analytics).to receive(:build)
+
+      progress_update.perform
+
+      expect(progress_update).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
Why:

* When registrations open we should have a periodic update.
* We can take leverage of the Heroku free tier by using the Heroku
Scheduler.
* To do that, we must run a rake task.

This change addresses the need by:

* Adding an incoming webhook for Slack.
* Refactoring the progress calculation to a separate service.
* Adding a service to send messages to Slack.