### PR TITLE
Reflect the registrations enable state on front page

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,10 @@
 module Admin
   class UsersController < Admin::ApplicationController
+    def index
+      @registrations_enabled = Settings.registrations_enabled?
+      super
+    end
+
     def create
       user_creation = UserCreation.new(user_params)
       user_creation.perform

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
 class HomeController < ApplicationController
-  def index; end
+  def index
+    @registrations_enabled = Settings.registrations_enabled?
+  end
 end

--- a/app/views/admin/users/index.slim
+++ b/app/views/admin/users/index.slim
@@ -26,8 +26,8 @@ header.main-content__header role="banner"
       )
 
   - registrations_message = @registrations_enabled ? "Disable registrations" : "Enable registrations"
-  
-  div style="margin-left: 10px"    
+
+  div style="margin-left: 10px"
     = link_to(                                                                                               \
         registrations_message,                           \
         admin_users_set_registrations_path(value: !@registrations_enabled),                                  \

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -1,1 +1,1 @@
-= render_react_component(component: "Home", prerender: true)
+= render_react_component(component: "Home", props: { registrations_enabled: @registrations_enabled }, prerender: true)

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,8 @@ module SecretSanta
     config.load_defaults 5.1
 
     config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    config.i18n.default_locale = :pt
+    config.i18n.default_locale = :en
+    config.react.camelize_props = true
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/frontend/components/SignUpClosed/index.css
+++ b/frontend/components/SignUpClosed/index.css
@@ -1,0 +1,84 @@
+@import '../../styles/variables.css';
+@import '../../styles/typography.css';
+@import '../../styles/layout.css';
+@import '../../styles/breakpoints.css';
+@import '../../styles/colors.css';
+
+.copy {
+  display: flex;
+  flex-direction: column;
+
+  @include Breakpoint-tabletAndAbove {
+    width: $five-columns;
+  }
+
+  @include Breakpoint-mobileOnly {
+    margin: 0 auto;
+
+    text-align: center;
+  }
+}
+
+.copy > *:not(:last-child) {
+  padding-bottom: $spacing-28;
+}
+
+.title {
+  margin-bottom: $spacing-56;
+}
+
+.form {
+  display: flex;
+  flex-direction: row;
+  margin-top: $spacing-56;
+
+  @include Breakpoint-tabletAndAbove {
+    margin-left: auto;
+  }
+
+  @include Breakpoint-mobileOnly {
+    flex-direction: column;
+
+    margin: $spacing-112 auto;
+  }
+
+  input {
+    width: 320px;
+
+    padding: $spacing-8 0 $spacing-8 0;
+
+    border: none;
+    border-bottom: solid $yellow 4px;
+
+    font-family: $font-family-sans-serif;
+    font-size: $font-size-medium;
+
+    @include Breakpoint-mobileOnly {
+      width: calc($min-content-width - $gutter - $gutter);
+
+      margin-bottom: $spacing-20;
+    }
+  }
+
+  input:focus {
+    outline: none;
+  }
+
+  input[name='user[name]'] {
+    margin-bottom: $spacing-28;
+  }
+}
+
+.join-us {
+  margin-top: auto;
+
+  @include Breakpoint-tabletAndAbove {
+    margin-left: $spacing-28;
+  }
+
+  @include Breakpoint-mobileOnly {
+    margin: 0 auto;
+
+    text-align: center;
+  }
+}

--- a/frontend/components/SignUpClosed/index.js
+++ b/frontend/components/SignUpClosed/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import Section from 'root/components/Section';
+import Text from 'root/components/Text';
+import Heading from 'root/components/Heading';
+
+import './index.css';
+
+const SignUp = () => (
+  <Section id="signUp">
+    <div styleName="copy">
+      <div styleName="title">
+        <Heading color="red" weight="bold" underline>
+          A Execução
+        </Heading>
+      </div>
+      <Text color="black">
+        De momento as nossas inscrições estão fechadas! Já conseguimos atribuir todas as cartas que temos de momento!
+      </Text>
+      <Text color="black">
+        No entanto, não desanimes. Nestas próximas semanas poderás ter a oportunidade de te registares como um rematcher, portanto fica atento às redes sociais para receberes notícias!
+      </Text>
+    </div>
+  </Section>
+);
+
+export default SignUp;

--- a/frontend/pages/Home/index.js
+++ b/frontend/pages/Home/index.js
@@ -1,21 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Header from 'root/components/Header';
 import Adventure from 'root/components/Adventure';
 import Plan from 'root/components/Plan';
 import SignUp from 'root/components/SignUp';
+import SignUpClosed from 'root/components/SignUpClosed';
 import Footer from 'root/components/Footer';
 
 import './index.css';
 
-const HomePage = () => (
+const HomePage = ({ registrationsEnabled }) => (
   <div styleName="root">
     <Header />
     <Adventure />
     <Plan />
-    <SignUp />
+    {registrationsEnabled ? <SignUp /> : <SignUpClosed />}
     <Footer />
   </div>
 );
+
+HomePage.propTypes = {
+  registrationsEnabled: PropTypes.bool.isRequired
+}
 
 export default HomePage;


### PR DESCRIPTION
Why:

* Users should not see the form when registrations are closed. 

This change addresses the need by:

* Fixing a whole lotta bugs :song:
* Passing a prop to the home page to know when registrations are enabled