### PR TITLE
Rake task to clean unreceived matches

### DIFF
--- a/app/models/unreceived_match.rb
+++ b/app/models/unreceived_match.rb
@@ -1,0 +1,12 @@
+class UnreceivedMatch < ApplicationRecord
+  belongs_to :user
+  belongs_to :receiver
+
+  validates :user_id,
+    presence: true,
+    uniqueness: { scope: :receiver_id }
+
+  validates :receiver_id, presence: true
+  validates :code, presence: true
+  validates :received, inclusion: { in: [true, false] }
+end

--- a/app/services/clean_unreceived_matches.rb
+++ b/app/services/clean_unreceived_matches.rb
@@ -1,0 +1,23 @@
+class CleanUnreceivedMatches
+  def perform
+    ActiveRecord::Base.transaction do
+      move_missing_matches
+    end
+  rescue ActiveRecord::ActiveRecordError => e
+    Rails.logger.error(e.message)
+  end
+
+  private
+
+  def move_missing_matches
+    Match.missing.each do |match|
+      UnreceivedMatch.create!(
+        user_id: match.user_id,
+        receiver_id: match.receiver_id,
+        code: match.code,
+        received: false,
+      )
+      match.destroy!
+    end
+  end
+end

--- a/lib/tasks/clean_unreceived_matches.rake
+++ b/lib/tasks/clean_unreceived_matches.rake
@@ -1,0 +1,5 @@
+desc "Clean unreceived matches"
+task clean_unreceived_matches: :environment do
+  service = CleanUnreceivedMatches.new
+  service.call
+end

--- a/spec/services/clean_unreceived_matches_spec.rb
+++ b/spec/services/clean_unreceived_matches_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe CleanUnreceivedMatches, type: :model do
+  describe "#perform" do
+    it "deletes all missing matches and creates them as unreceived matches" do
+      create(:match, received: false)
+      missing_matches_count = Match.missing.count
+      clean_unreceived_matches = CleanUnreceivedMatches.new
+
+      expect do
+        clean_unreceived_matches.perform
+      end.to change { UnreceivedMatch.count }.by(missing_matches_count)
+    end
+
+    it "creates unreceived match with the correct data" do
+      unreceived_match = create(:match, received: false)
+      clean_unreceived_matches = CleanUnreceivedMatches.new
+
+      clean_unreceived_matches.perform
+
+      expect(unreceived_match.user_id).to eq(UnreceivedMatch.first.user_id)
+      expect(unreceived_match.receiver_id).to eq(UnreceivedMatch.first.receiver_id)
+      expect(unreceived_match.code).to eq(UnreceivedMatch.first.code)
+    end
+
+    it "does nothing when there are no missing matches" do
+      create(:match, received: true)
+      clean_unreceived_matches = CleanUnreceivedMatches.new
+
+      match_count = Match.count
+      expect do
+        clean_unreceived_matches.perform
+      end.not_to change { Match.count }.from(match_count)
+      expect(UnreceivedMatch.all).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Why:
* https://trello.com/c/iM0jta7I

These changes address the issue by:
* Adding an UnreceivedMatch model. This is essentially a copy of the
  Match model, minus the scopes
* Adding a service object to move the missing matches to the new model
* Adding a rake task to call the service object