### PR TITLE
Use MatchAssignment service in the admin dashboard

### DIFF
--- a/app/controllers/admin/matches_controller.rb
+++ b/app/controllers/admin/matches_controller.rb
@@ -1,5 +1,18 @@
 module Admin
   class MatchesController < Admin::ApplicationController
+    def create
+      match_assigment = MatchAssignment.new(find_user)
+      match_assigment.perform
+
+      if match_assigment.successful?
+        flash[:notice] = "Match created!"
+        redirect_to admin_match_path(match_assigment.match)
+      else
+        flash[:error] = "Something went wrong."
+        redirect_to admin_matches_path
+      end
+    end
+
     def received
       match = Match.find(params[:match_id])
       match.update(received: true)
@@ -7,6 +20,20 @@ module Admin
       flash[:notice] = "Match marked as received!"
 
       redirect_to admin_matches_path
+    end
+
+    private
+
+    def find_user
+      User.find(match_params[:user_id])
+    end
+
+    def find_match
+      Match.find(match_params[:match_id])
+    end
+
+    def match_params
+      params.require(:match).permit(:user_id, :match_id)
     end
   end
 end

--- a/spec/services/match_assignment_spec.rb
+++ b/spec/services/match_assignment_spec.rb
@@ -12,8 +12,22 @@ RSpec.describe MatchAssignment, type: :model do
       end.to change { Match.count }.by(1)
 
       expect(match_assignment).to be_successful
-      expect(Match.first.receiver).to eq(receiver)
-      expect(Match.first.user).to eq(user)
+      expect(match_assignment.match.receiver).to eq(receiver)
+      expect(match_assignment.match.user).to eq(user)
+    end
+
+    it "creates a match for a given receiver" do
+      user = create(:user)
+      receiver = create_list(:receiver, 3).last
+      match_assignment = MatchAssignment.new(user, receiver)
+
+      expect do
+        match_assignment.perform
+      end.to change { Match.count }.by(1)
+
+      expect(match_assignment).to be_successful
+      expect(match_assignment.match.receiver).to eq(receiver)
+      expect(match_assignment.match.user).to eq(user)
     end
 
     it "is unsuccessful if there are no receivers" do
@@ -25,7 +39,7 @@ RSpec.describe MatchAssignment, type: :model do
       expect(match_assignment).not_to be_successful
     end
 
-    it "is unsuccesful if the user already has a match" do
+    it "is unsuccessful if the user already has a match" do
       user = create(:user)
       create(:receiver)
       create(:receiver)
@@ -59,6 +73,16 @@ RSpec.describe MatchAssignment, type: :model do
       match_assignment.perform
 
       expect(match_assignment.receiver).to eq(available_receiver)
+    end
+
+    it "is unsuccessful if receiver already has match" do
+      match = create(:match)
+      user = create(:user)
+      match_assignment = MatchAssignment.new(user, match.receiver)
+
+      match_assignment.perform
+
+      expect(match_assignment).to_not be_successful
     end
   end
 end


### PR DESCRIPTION
Why:

* We need to create custom matches, and we needed the logic used in the match assignment

This change addresses the need by:

* Adding an optional `receiver` argument to the MatchAssignment service to create a match with that specific receiver.